### PR TITLE
Update spec to include the new upper-bound

### DIFF
--- a/specs/fjord/predeploys.md
+++ b/specs/fjord/predeploys.md
@@ -23,14 +23,19 @@ section.
 
 A new method is introduced: `getL1FeeUpperBound(uint256)`. This method returns an upper bound for the L1 fee
 for a given transaction size. It is provided for callers who wish to estimate L1 transaction costs in the
-write path, and is much more gas efficient than `getL1Fee`. It assumes the worst case of no compression,
+write path, and is much more gas efficient than `getL1Fee`.
+
+The upper limit overhead is assumed to be `original/255+16`, borrowed from LZ4. According to historical data, this approach can encompass more than 99.998% of transactions.
+
 implemented as follows:
 
 ```solidity
 function getL1FeeUpperBound(uint256 unsignedTxSize) external view returns (uint256) {
-    int256 txSize = int256(unsignedTxSize) + 68;
+    int256 txSize = int256(_unsignedTxSize) + 68;
+    // txSize / 255 + 16 is the pratical fastlz upper-bound covers %99.99 txs.
+    int256 flzUpperBound = txSize + txSize / 255 + 16;
     uint256 feeScaled = baseFeeScalar() * 16 * l1BaseFee() + blobBaseFeeScalar() * blobBaseFee();
-    int256 cost = costIntercept + costFastlzCoef * txSize + costTxSizeCoef * txSize;
+    int256 cost = costIntercept + costFastlzCoef * flzUpperBound + costTxSizeCoef * txSize;
     if (cost < 0) {
         cost = 0;
     }

--- a/specs/fjord/predeploys.md
+++ b/specs/fjord/predeploys.md
@@ -25,14 +25,14 @@ A new method is introduced: `getL1FeeUpperBound(uint256)`. This method returns a
 for a given transaction size. It is provided for callers who wish to estimate L1 transaction costs in the
 write path, and is much more gas efficient than `getL1Fee`.
 
-The upper limit overhead is assumed to be `original/255+16`, borrowed from LZ4. According to historical data, this approach can encompass more than 99.998% of transactions.
+The upper limit overhead is assumed to be `original/255+16`, borrowed from LZ4. According to historical data, this approach can encompass more than 99.99% of transactions.
 
 implemented as follows:
 
 ```solidity
 function getL1FeeUpperBound(uint256 unsignedTxSize) external view returns (uint256) {
-    int256 txSize = int256(_unsignedTxSize) + 68;
-    // txSize / 255 + 16 is the pratical fastlz upper-bound covers %99.99 txs.
+    int256 txSize = int256(unsignedTxSize) + 68;
+    // txSize / 255 + 16 is the pratical fastlz upper-bound covers 99.99% txs.
     int256 flzUpperBound = txSize + txSize / 255 + 16;
     uint256 feeScaled = baseFeeScalar() * 16 * l1BaseFee() + blobBaseFeeScalar() * blobBaseFee();
     int256 cost = costIntercept + costFastlzCoef * flzUpperBound + costTxSizeCoef * txSize;


### PR DESCRIPTION
Add the new overhead `original/255+16`. It is borrowed from LZ4, which is different from what we use (LZ77). However it provides a better estimation and covers over 99.998% txs.